### PR TITLE
Update default_realworld.py

### DIFF
--- a/train_settings/dbsr/default_realworld.py
+++ b/train_settings/dbsr/default_realworld.py
@@ -52,7 +52,7 @@ def run(settings):
     burstsr_val = datasets.BurstSRDataset(split='val')
 
     # Train sampler and loader
-    dataset_val = sampler.IndexedBurst([burstsr_val], burst_size=settings.burst_sz, processing=data_processing_val)
+    dataset_val = sampler.IndexedBurst(burstsr_val, burst_size=settings.burst_sz, processing=data_processing_val)
     loader_val = DataLoader('val', dataset_val, training=False, num_workers=settings.num_workers,
                             stack_dim=0, batch_size=settings.batch_size)
 


### PR DESCRIPTION
Removed the listing of `burstsr_val` in the `sampler.IndexedBurst` argument. The `sampler.IndexedBurst` class does not expect datasets to be passed as a list, but rather expects a single dataset as an argument. This update ensures compatibility with the expected input type in `IndexedBurst`.

Currently, without this fix, the val dataset will not be processed correctly, as `sampler.IndexedBurst` is not designed to handle a list of datasets.